### PR TITLE
random testing: add for-all* macro

### DIFF
--- a/src/package.lisp
+++ b/src/package.lisp
@@ -52,6 +52,7 @@
    #:fail
    #:*test-dribble*
    #:for-all
+   #:for-all*
    #:*num-trials*
    #:*max-trials*
    #:gen-integer

--- a/t/tests.lisp
+++ b/t/tests.lisp
@@ -265,6 +265,11 @@
     (is (= 2 (length s)))
     (is (every (curry #'char= #\Null) s))))
 
+(def-test for-all* ()
+  (for-all* ((a (gen-integer))
+             (b (gen-integer :min a :max (+ a 10))))
+    (is (<= a b))))
+
 (defun dummy-mv-generator ()
   (lambda ()
     (list 1 1)))
@@ -273,6 +278,18 @@
   (for-all (((a b) (dummy-mv-generator)))
     (is (= 1 a))
     (is (= 1 b))))
+
+(defun dummy-mv-generator* (val)
+  (lambda ()
+    (list val (1+ val))))
+
+(def-test for-all*-destructuring-bind ()
+  (for-all* (((a b) (dummy-mv-generator* 1))
+             ((c d) (dummy-mv-generator* (1+ b))))
+    (is (= 1 a))
+    (is (= 2 b))
+    (is (= 3 c))
+    (is (= 4 d))))
 
 (def-test return-values ()
   "Return values indicate test failures."


### PR DESCRIPTION
FOR-ALL* macro does sequential binding for generated values (FOR-ALL*
is related to FOR-ALL as LET* is related to LET). This approach allows
using random values to initialize generators down the line without a
necessity to nest the FOR-ALL macro (what increases number of trials
exponentially).