### PR TITLE
Muffle SBCL style-warning for `run!` lambda list

### DIFF
--- a/src/run.lisp
+++ b/src/run.lisp
@@ -274,10 +274,11 @@ run."))
 
 ;;;; ** Public entry points
 
-(defun run! (&optional (test-spec *suite*)
-             &key ((:print-names *print-names*) *print-names*))
-  "Equivalent to (explain! (run TEST-SPEC))."
-  (explain! (run test-spec)))
+(locally (declare #+sbcl (sb-ext:muffle-conditions sb-kernel:&optional-and-&key-in-lambda-list))
+  (defun run! (&optional (test-spec *suite*)
+               &key ((:print-names *print-names*) *print-names*))
+    "Equivalent to (explain! (run TEST-SPEC))."
+    (explain! (run test-spec))))
 
 (defun explain! (result-list)
   "Explain the results of RESULT-LIST using a


### PR DESCRIPTION
SBCL issues a style-warning of class `sb-kernel:&optional-and-&key-in-lambda-list` when both `&optional` and `&key` arguments appear in the same lambda list. FiveAM has one such lambda list, for `run!`. This causes `(asdf:load-system "fiveam")` to print output like:

```
; file: /Users/phoebe/quicklisp/local-projects/fiveam/src/run.lisp
; in: DEFUN RUN!
;     (DEFUN IT.BESE.FIVEAM:RUN!
;            (
;             &OPTIONAL (IT.BESE.FIVEAM::TEST-SPEC IT.BESE.FIVEAM::*SUITE*)
;             &KEY
;             ((:PRINT-NAMES IT.BESE.FIVEAM:*PRINT-NAMES*)
;              IT.BESE.FIVEAM:*PRINT-NAMES*))
;       "Equivalent to (explain! (run TEST-SPEC))."
;       (IT.BESE.FIVEAM:EXPLAIN! (IT.BESE.FIVEAM:RUN IT.BESE.FIVEAM::TEST-SPEC)))
; --> PROGN SB-IMPL::%DEFUN SB-IMPL::%DEFUN SB-INT:NAMED-LAMBDA 
; ==>
;   #'(SB-INT:NAMED-LAMBDA IT.BESE.FIVEAM:RUN!
;         (&OPTIONAL (IT.BESE.FIVEAM::TEST-SPEC IT.BESE.FIVEAM::*SUITE*) &KEY
;          ((:PRINT-NAMES IT.BESE.FIVEAM:*PRINT-NAMES*)
;           IT.BESE.FIVEAM:*PRINT-NAMES*))
;       (DECLARE (SB-C::TOP-LEVEL-FORM))
;       "Equivalent to (explain! (run TEST-SPEC))."
;       (BLOCK IT.BESE.FIVEAM:RUN!
;         (IT.BESE.FIVEAM:EXPLAIN!
;          (IT.BESE.FIVEAM:RUN IT.BESE.FIVEAM::TEST-SPEC))))
; 
; caught STYLE-WARNING:
;   &OPTIONAL and &KEY found in the same lambda list: (&OPTIONAL
;                                                      (TEST-SPEC *SUITE*) &KEY
;                                                      ((PRINT-NAMES *PRINT-NAMES*)
;                                                       *PRINT-NAMES*))
```

This commit encloses the definition of `run!` inside of a `locally declare muffle-warnings` form to suppress the warning, since I believe altering the lambda list to suit SBCL's style guide is neither feasible nor desirable.