### PR TITLE
Add Lispwork's DSPEC functionality to tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,17 +8,17 @@ env:
     - LISP=ccl
     - LISP=ecl
     - LISP=abcl
+    - LISP=clisp
     - LISP=allegro
-    - LISP=ccl32
     - LISP=sbcl32
-    - LISP=cmucl
+    - LISP=ccl32
+    # - LISP=cmucl
 
 jobs:
   allow_failures:
-    - env: LISP=allegro
-    - env: LISP=ccl32
-    - env: LISP=cmucl
     - env: LISP=sbcl32
+    - env: LISP=ccl32
+    # - env: LISP=cmucl
 
 notifications:
   email:


### PR DESCRIPTION
This lets you jump to tests given the name on Lispworks (for instance, using M-. in Sly/Slime)

This is particularly useful for slite: https://github.com/tdrhq/slite

I've been using this for a few years now, and have been putting off merging this change in. It should be mostly a no-op except for registering the DSPEC lookup code.